### PR TITLE
feat: Adding Volcano Batch Scheduler Helm Chart 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: detect-aws-credentials
         args: ['--allow-missing-credentials']
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.81.0
+    rev: v1.83.2
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ module "eks_data_addons" {
 | [helm_release.spark_history_server](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.spark_operator](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.strimzi_kafka_operator](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [helm_release.volcano](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.yunikorn](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
@@ -126,6 +127,7 @@ module "eks_data_addons" {
 | <a name="input_enable_spark_history_server"></a> [enable\_spark\_history\_server](#input\_enable\_spark\_history\_server) | Enable Spark History Server add-on | `bool` | `false` | no |
 | <a name="input_enable_spark_operator"></a> [enable\_spark\_operator](#input\_enable\_spark\_operator) | Enable Spark on K8s Operator add-on | `bool` | `false` | no |
 | <a name="input_enable_strimzi_kafka_operator"></a> [enable\_strimzi\_kafka\_operator](#input\_enable\_strimzi\_kafka\_operator) | Enable the Strimzi Kafka Operator | `bool` | `false` | no |
+| <a name="input_enable_volcano"></a> [enable\_volcano](#input\_enable\_volcano) | Enable volcano scheduler add-on | `bool` | `false` | no |
 | <a name="input_enable_yunikorn"></a> [enable\_yunikorn](#input\_enable\_yunikorn) | Enable Apache YuniKorn K8s scheduler add-on | `bool` | `false` | no |
 | <a name="input_flink_operator_helm_config"></a> [flink\_operator\_helm\_config](#input\_flink\_operator\_helm\_config) | Flink Operator Helm Chart config | `any` | `{}` | no |
 | <a name="input_jupyterhub_helm_config"></a> [jupyterhub\_helm\_config](#input\_jupyterhub\_helm\_config) | Helm configuration for JupyterHub | `any` | `{}` | no |
@@ -136,6 +138,7 @@ module "eks_data_addons" {
 | <a name="input_spark_history_server_helm_config"></a> [spark\_history\_server\_helm\_config](#input\_spark\_history\_server\_helm\_config) | Helm configuration for Spark History Server | `any` | `{}` | no |
 | <a name="input_spark_operator_helm_config"></a> [spark\_operator\_helm\_config](#input\_spark\_operator\_helm\_config) | Helm configuration for Spark K8s Operator | `any` | `{}` | no |
 | <a name="input_strimzi_kafka_operator_helm_config"></a> [strimzi\_kafka\_operator\_helm\_config](#input\_strimzi\_kafka\_operator\_helm\_config) | Helm configuration for Strimzi Kafka Operator | `any` | `{}` | no |
+| <a name="input_volcano_helm_config"></a> [volcano\_helm\_config](#input\_volcano\_helm\_config) | Volcano scheduler add-on configurations | `any` | `{}` | no |
 | <a name="input_yunikorn_helm_config"></a> [yunikorn\_helm\_config](#input\_yunikorn\_helm\_config) | Helm configuration for Apache YuniKorn | `any` | `{}` | no |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -157,5 +157,6 @@ module "eks_data_addons" {
 | <a name="output_spark_history_server"></a> [spark\_history\_server](#output\_spark\_history\_server) | Spark History Server Helm Chart metadata |
 | <a name="output_spark_operator"></a> [spark\_operator](#output\_spark\_operator) | Spark Operator Helm Chart metadata |
 | <a name="output_strimzi_kafka_operator"></a> [strimzi\_kafka\_operator](#output\_strimzi\_kafka\_operator) | Strimzi Kafka Operator Helm Chart metadata |
+| <a name="output_volcano"></a> [volcano](#output\_volcano) | Volcano Batch Scheduler Helm Chart metadata |
 | <a name="output_yunikorn"></a> [yunikorn](#output\_yunikorn) | Yunikorn Helm Chart metadata |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -62,3 +62,8 @@ output "kuberay_operator" {
   value       = try(helm_release.kuberay_operator[0].metadata, null)
   description = "Kuberay Operator Helm Chart metadata"
 }
+
+output "volcano" {
+  value       = try(helm_release.volcano[0].metadata, null)
+  description = "Volcano Batch Scheduler Helm Chart metadata"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -213,9 +213,9 @@ variable "cnpg_operator_helm_config" {
   default     = {}
 }
 
-################################################################################
-# Volcano Scheduler for TorchX
-################################################################################
+#---------------------------------------------------
+# Volcano Batch Scheduler
+#---------------------------------------------------
 
 variable "enable_volcano" {
   description = "Enable volcano scheduler add-on"

--- a/variables.tf
+++ b/variables.tf
@@ -216,7 +216,6 @@ variable "cnpg_operator_helm_config" {
 #---------------------------------------------------
 # Volcano Batch Scheduler
 #---------------------------------------------------
-
 variable "enable_volcano" {
   description = "Enable volcano scheduler add-on"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -212,3 +212,19 @@ variable "cnpg_operator_helm_config" {
   type        = any
   default     = {}
 }
+
+################################################################################
+# Volcano Scheduler for TorchX
+################################################################################
+
+variable "enable_volcano" {
+  description = "Enable volcano scheduler add-on"
+  type        = bool
+  default     = false
+}
+
+variable "volcano_helm_config" {
+  description = "Volcano scheduler add-on configurations"
+  type        = any
+  default     = {}
+}

--- a/volcano.tf
+++ b/volcano.tf
@@ -1,0 +1,66 @@
+################################################################################
+# Volcano Scheduler for TorchX
+################################################################################
+
+resource "helm_release" "volcano" {
+  count = var.enable_volcano ? 1 : 0
+  
+  name                       = try(var.volcano_helm_config["name"], "volcano")
+  repository                 = try(var.volcano_helm_config["repository"], "https://github.com/volcano-sh/volcano.git/")
+  chart                      = try(var.volcano_helm_config["chart"], "volcano")
+  version                    = try(var.volcano_helm_config["version"], "1.5")
+  timeout                    = try(var.volcano_helm_config["timeout"], 300)
+  values                     = try(var.volcano_helm_config["values"], null)
+  create_namespace           = try(var.volcano_helm_config["create_namespace"], true)
+  namespace                  = try(var.volcano_helm_config["namespace"], "volcano")
+  lint                       = try(var.volcano_helm_config["lint"], false)
+  description                = try(var.volcano_helm_config["description"], "")
+  repository_key_file        = try(var.volcano_helm_config["repository_key_file"], "")
+  repository_cert_file       = try(var.volcano_helm_config["repository_cert_file"], "")
+  repository_username        = try(var.volcano_helm_config["repository_username"], "")
+  repository_password        = try(var.volcano_helm_config["repository_password"], "")
+  verify                     = try(var.volcano_helm_config["verify"], false)
+  keyring                    = try(var.volcano_helm_config["keyring"], "")
+  disable_webhooks           = try(var.volcano_helm_config["disable_webhooks"], false)
+  reuse_values               = try(var.volcano_helm_config["reuse_values"], false)
+  reset_values               = try(var.volcano_helm_config["reset_values"], false)
+  force_update               = try(var.volcano_helm_config["force_update"], false)
+  recreate_pods              = try(var.volcano_helm_config["recreate_pods"], false)
+  cleanup_on_fail            = try(var.volcano_helm_config["cleanup_on_fail"], false)
+  max_history                = try(var.volcano_helm_config["max_history"], 0)
+  atomic                     = try(var.volcano_helm_config["atomic"], false)
+  skip_crds                  = try(var.volcano_helm_config["skip_crds"], false)
+  render_subchart_notes      = try(var.volcano_helm_config["render_subchart_notes"], true)
+  disable_openapi_validation = try(var.volcano_helm_config["disable_openapi_validation"], false)
+  wait                       = try(var.volcano_helm_config["wait"], true)
+  wait_for_jobs              = try(var.volcano_helm_config["wait_for_jobs"], false)
+  dependency_update          = try(var.volcano_helm_config["dependency_update"], false)
+  replace                    = try(var.volcano_helm_config["replace"], false)
+
+  postrender {
+    binary_path = try(var.volcano_helm_config["postrender"], "")
+  }
+
+  dynamic "set" {
+    iterator = each_item
+    for_each = try(var.volcano_helm_config["set"], [])
+
+    content {
+      name  = each_item.value.name
+      value = each_item.value.value
+      type  = try(each_item.value.type, null)
+    }
+  }
+
+  dynamic "set_sensitive" {
+    iterator = each_item
+    for_each = try(var.volcano_helm_config["set_sensitive"], [])
+
+    content {
+      name  = each_item.value.name
+      value = each_item.value.value
+      type  = try(each_item.value.type, null)
+    }
+  }
+
+}

--- a/volcano.tf
+++ b/volcano.tf
@@ -6,6 +6,7 @@ locals {
   volcano_name      = "volcano"
   volcano_namespace = "volcano-system"
 }
+
 resource "helm_release" "volcano" {
   count = var.enable_volcano ? 1 : 0
 

--- a/volcano.tf
+++ b/volcano.tf
@@ -4,7 +4,7 @@
 
 resource "helm_release" "volcano" {
   count = var.enable_volcano ? 1 : 0
-  
+
   name                       = try(var.volcano_helm_config["name"], "volcano")
   repository                 = try(var.volcano_helm_config["repository"], "https://github.com/volcano-sh/volcano.git/")
   chart                      = try(var.volcano_helm_config["chart"], "volcano")

--- a/volcano.tf
+++ b/volcano.tf
@@ -1,18 +1,22 @@
 ################################################################################
-# Volcano Scheduler for TorchX
+# Volcano Batch Scheduler
 ################################################################################
 
+locals {
+  volcano_name      = "volcano"
+  volcano_namespace = "volcano-system"
+}
 resource "helm_release" "volcano" {
   count = var.enable_volcano ? 1 : 0
 
-  name                       = try(var.volcano_helm_config["name"], "volcano")
-  repository                 = try(var.volcano_helm_config["repository"], "https://github.com/volcano-sh/volcano.git/")
-  chart                      = try(var.volcano_helm_config["chart"], "volcano")
-  version                    = try(var.volcano_helm_config["version"], "1.5")
+  name                       = try(var.volcano_helm_config["name"], local.volcano_name)
+  repository                 = try(var.volcano_helm_config["repository"], "https://volcano-sh.github.io/helm-charts")
+  chart                      = try(var.volcano_helm_config["chart"], local.volcano_name)
+  version                    = try(var.volcano_helm_config["version"], "1.8")
   timeout                    = try(var.volcano_helm_config["timeout"], 300)
   values                     = try(var.volcano_helm_config["values"], null)
   create_namespace           = try(var.volcano_helm_config["create_namespace"], true)
-  namespace                  = try(var.volcano_helm_config["namespace"], "volcano")
+  namespace                  = try(var.volcano_helm_config["namespace"], local.volcano_namespace)
   lint                       = try(var.volcano_helm_config["lint"], false)
   description                = try(var.volcano_helm_config["description"], "")
   repository_key_file        = try(var.volcano_helm_config["repository_key_file"], "")


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/blob/main/.github/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

Added helm chart for volcano
### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #304 from repo: [data-on-eks](https://github.com/awslabs/data-on-eks)

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->


01.repos/terraform-aws-eks-data-addons - (main) > pre-commit run --all-files
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check for merge conflicts................................................Passed
detect private key.......................................................Passed
detect aws credentials...................................................Passed
Terraform fmt............................................................Passed
Terraform docs...........................................................Passed
Terraform validate with tflint...........................................Passed
Terraform validate.......................................................Passed

terraform plan was successful

01.repos/terraform-aws-eks-data-addons - (main) > terraform plan    
var.oidc_provider_arn
  The ARN of the cluster OIDC Provider

  Enter a value: arn:aws:iam::090185061218:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/10F979574F7DEB82000945A1A308FCDA

data.aws_partition.current: Reading...
data.aws_region.current: Reading...
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.current: Read complete after 0s [id=us-west-2]

Changes to Outputs:
  + aws_efa_k8s_device_plugin = []
  + aws_neuron_device_plugin  = []

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.
