### PR TITLE
fix: Update helm repo for spark operator

### DIFF
--- a/spark-operator.tf
+++ b/spark-operator.tf
@@ -1,6 +1,6 @@
 locals {
   spark_operator_name       = "spark-operator"
-  spark_operator_repository = "https://googlecloudplatform.github.io/spark-on-k8s-operator"
+  spark_operator_repository = "https://kubeflow.github.io/spark-operator"
   spark_operator_version    = "1.1.27"
 }
 


### PR DESCRIPTION
### What does this PR do?
The Spark operator repo moved to https://github.com/kubeflow/spark-operator 
This PR updates the repo in our addon to reference the new Chart location https://kubeflow.github.io/spark-operator

### Motivation
Seeing reports of 404s around that chart move https://github.com/kubeflow/spark-operator/issues/1926 

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
