### PR TITLE
Fix: Added condition to filter consolidation policy for Karpenter Resources

### DIFF
--- a/helm-charts/karpenter-resources/templates/node-pool.yaml
+++ b/helm-charts/karpenter-resources/templates/node-pool.yaml
@@ -19,15 +19,17 @@ spec:
         name: {{ .Values.name }}
       {{- with .Values.nodePool.taints }}
       taints:
-        {{- toYaml . | nindent 8 }}
+      {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.nodePool.requirements }}
       requirements:
-        {{- toYaml . | nindent 8 }}
+      {{- toYaml . | nindent 8 }}
       {{- end }}
   disruption:
     consolidationPolicy: {{ .Values.nodePool.disruption.consolidationPolicy }}
-    consolidateAfter: {{ .Values.nodePool.disruption.consolidateAfter }}
+    {{- if eq .Values.nodePool.disruption.consolidationPolicy "WhenEmpty" }}
+    consolidateAfter: {{ .Values.nodePool.disruption.consolidateAfter }} # Only defined if consolidationPolicy is WhenEmpty
+    {{- end }}
     expireAfter: {{ .Values.nodePool.disruption.expireAfter }}
   limits:
     cpu: {{ .Values.nodePool.limits.cpu }}


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/blob/main/.github/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

I'm using Karpenter Resources from DoEKS add-ons for a demo, and I noticed that using WhenUnderutilized the nodepool was not being created, this was because the consolidateAfter key was being added even with WhenUnderutilized which is not right.

### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [X] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

No
