### PR TITLE
fix: Update neuron helm chart version

### DIFF
--- a/aws-neuron-device-plugin.tf
+++ b/aws-neuron-device-plugin.tf
@@ -4,7 +4,7 @@ resource "helm_release" "aws_neuron_device_plugin" {
   name                       = try(var.aws_neuron_device_plugin_helm_config["name"], "neuron-helm-chart")
   repository                 = try(var.aws_neuron_device_plugin_helm_config["repository"], null)
   chart                      = try(var.aws_neuron_device_plugin_helm_config["chart"], "oci://public.ecr.aws/neuron/neuron-helm-chart")
-  version                    = try(var.aws_neuron_device_plugin_helm_config["version"], "1.0.0")
+  version                    = try(var.aws_neuron_device_plugin_helm_config["version"], "1.1.1")
   timeout                    = try(var.aws_neuron_device_plugin_helm_config["timeout"], 300)
   values                     = try(var.aws_neuron_device_plugin_helm_config["values"], null)
   create_namespace           = try(var.aws_neuron_device_plugin_helm_config["create_namespace"], false)


### PR DESCRIPTION
### What does this PR do?

Updates the neuron helm chart to version 1.1.1, which fixes a scheduler issue for multi neuron devices

### Motivation

<!-- What inspired you to submit this pull request? -->
- Fixes a scheduler issue that prevents scheduling of pods requiring more than one neuron device. 

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

